### PR TITLE
fix: make this work on M1+ macs

### DIFF
--- a/krew-plugins.nix
+++ b/krew-plugins.nix
@@ -57,7 +57,7 @@ let
       };
       sourceRoot = ".";
       dontBuild = true;
-      nativeBuildInputs = [ autoPatchelfHook ];
+      nativeBuildInputs = lib.optionals (!stdenv.isDarwin) [ autoPatchelfHook ];
       installPhase = ''
         runHook preInstall
         mkdir -p $out/{bin,lib}


### PR DESCRIPTION
`autoPatchelfHook` does not work on M1+ Macs